### PR TITLE
Upgrade to elasticsearch 7.1

### DIFF
--- a/app/com/thumbtack/becquerel/BecquerelServiceEntityCollectionProcessor.scala
+++ b/app/com/thumbtack/becquerel/BecquerelServiceEntityCollectionProcessor.scala
@@ -53,14 +53,6 @@ class BecquerelServiceEntityCollectionProcessor(
   override def init(odata: OData, serviceMetadata: ServiceMetadata): Unit = {
     this.odata = odata
     this.serviceMetadata = serviceMetadata
-
-    val schema = serviceMetadata.getEdm().getSchemas().head
-    logger.debug(s"schema: nameSpace=${schema.getNamespace()} alias=${schema.getAlias()}")
-    val entityContainer = schema.getEntityContainer()
-    entityContainer.getEntitySets.foreach { entitySet =>
-      logger.debug(s"entitySet.name=${entitySet.getName()} entitySet.mapping=${entitySet.getMapping()}")
-    }
-
     defaultProcessor.init(odata, serviceMetadata)
   }
 
@@ -76,7 +68,6 @@ class BecquerelServiceEntityCollectionProcessor(
     responseFormat: ContentType
   ): Unit = {
 
-    logger.debug(s"BecquerelServiceEntityCollectionProcessor:readEntityCollection uriInfo=$uriInfo responseFormat=$responseFormat")
     require(odata != null)
     require(serviceMetadata != null)
 
@@ -94,8 +85,6 @@ class BecquerelServiceEntityCollectionProcessor(
 
     val baseURI = new URI(request.getRawRequestUri)
 
-    logger.debug(s"Invoking odataTry(query): entitySet=$entitySet")
-
     val entityCollection = odataTry("query") {
       Await.result(
         service.query(
@@ -112,8 +101,6 @@ class BecquerelServiceEntityCollectionProcessor(
         service.queryTimeout
       )
     }
-
-    logger.debug(s"Invoking odataTry(serialize): entityCollection=$entityCollection")
 
     odataTry("serialize") {
       serialize(

--- a/app/com/thumbtack/becquerel/BecquerelServiceEntityCollectionProcessor.scala
+++ b/app/com/thumbtack/becquerel/BecquerelServiceEntityCollectionProcessor.scala
@@ -55,10 +55,10 @@ class BecquerelServiceEntityCollectionProcessor(
     this.serviceMetadata = serviceMetadata
 
     val schema = serviceMetadata.getEdm().getSchemas().head
-    logger.info(s"schema: nameSpace=${schema.getNamespace()} alias=${schema.getAlias()}")
+    logger.debug(s"schema: nameSpace=${schema.getNamespace()} alias=${schema.getAlias()}")
     val entityContainer = schema.getEntityContainer()
     entityContainer.getEntitySets.foreach { entitySet =>
-      logger.info(s"entitySet.name=${entitySet.getName()} entitySet.mapping=${entitySet.getMapping()}")
+      logger.debug(s"entitySet.name=${entitySet.getName()} entitySet.mapping=${entitySet.getMapping()}")
     }
 
     defaultProcessor.init(odata, serviceMetadata)
@@ -76,7 +76,7 @@ class BecquerelServiceEntityCollectionProcessor(
     responseFormat: ContentType
   ): Unit = {
 
-    logger.info(s"BecquerelServiceEntityCollectionProcessor:readEntityCollection uriInfo=$uriInfo responseFormat=$responseFormat")
+    logger.debug(s"BecquerelServiceEntityCollectionProcessor:readEntityCollection uriInfo=$uriInfo responseFormat=$responseFormat")
     require(odata != null)
     require(serviceMetadata != null)
 
@@ -94,7 +94,7 @@ class BecquerelServiceEntityCollectionProcessor(
 
     val baseURI = new URI(request.getRawRequestUri)
 
-    logger.info(s"Invoking odataTry(query): entitySet=$entitySet")
+    logger.debug(s"Invoking odataTry(query): entitySet=$entitySet")
 
     val entityCollection = odataTry("query") {
       Await.result(
@@ -113,7 +113,7 @@ class BecquerelServiceEntityCollectionProcessor(
       )
     }
 
-    logger.info(s"Invoking odataTry(serialize): entityCollection=$entityCollection")
+    logger.debug(s"Invoking odataTry(serialize): entityCollection=$entityCollection")
 
     odataTry("serialize") {
       serialize(

--- a/app/com/thumbtack/becquerel/controllers/HomeController.scala
+++ b/app/com/thumbtack/becquerel/controllers/HomeController.scala
@@ -71,6 +71,8 @@ class HomeController @Inject() (
     * Publish a service as OData.
     */
   def odataService(name: String, path: String): Action[RawBuffer] = {
+    logger.info(s"odataService: Received request. name=$name path=$path")
+
     Action.async(parse.raw) { request =>
       implicit val ec: ExecutionContextExecutor = actorSystem.dispatcher
 
@@ -78,10 +80,15 @@ class HomeController @Inject() (
 
       serviceManager(name).map { service =>
 
+        logger.info(s"service.name=${service.name} service.describe=${service.describe}")
+        // logger.info(s"service.metadata=${service.metadata}")
+
         val odata = OData.newInstance()
         val edm = odata.createServiceMetadata(service.metadata, Seq.empty[EdmxReference].asJava)
         val handler = odata.createHandler(edm)
         handler.register(new BecquerelServiceEntityCollectionProcessor(service, runID))
+
+        logger.info(s"Registered handler for service: $name")
 
         implicit val requestHeader: RequestHeader = request
         val reverseRouter = routes.HomeController.odataService(name, path)

--- a/app/com/thumbtack/becquerel/controllers/HomeController.scala
+++ b/app/com/thumbtack/becquerel/controllers/HomeController.scala
@@ -71,18 +71,12 @@ class HomeController @Inject() (
     * Publish a service as OData.
     */
   def odataService(name: String, path: String): Action[RawBuffer] = {
-    logger.info(s"odataService: Received request. name=$name path=$path")
-
     Action.async(parse.raw) { request =>
       implicit val ec: ExecutionContextExecutor = actorSystem.dispatcher
 
       val runID = request.headers.get(RunIDFilter.header)
 
       serviceManager(name).map { service =>
-
-        logger.info(s"service.name=${service.name} service.describe=${service.describe}")
-        // logger.info(s"service.metadata=${service.metadata}")
-
         val odata = OData.newInstance()
         val edm = odata.createServiceMetadata(service.metadata, Seq.empty[EdmxReference].asJava)
         val handler = odata.createHandler(edm)

--- a/app/com/thumbtack/becquerel/datasources/DataSourceService.scala
+++ b/app/com/thumbtack/becquerel/datasources/DataSourceService.scala
@@ -209,6 +209,8 @@ trait DataSourceService[Column, Row, Schema, Query] extends BecquerelService {
       skip
     )
 
+    logger.debug(s"compiledQuery:\n$compiledQuery")
+
     errorsMeter.countFutureErrors {
       queryTimer.timeFuture {
         execute(compiledQuery).map { rows =>

--- a/app/com/thumbtack/becquerel/datasources/bigquery/BqService.scala
+++ b/app/com/thumbtack/becquerel/datasources/bigquery/BqService.scala
@@ -26,6 +26,7 @@ import scala.collection.mutable
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future, blocking}
 import scala.util.control.NonFatal
+import play.api.Logger
 
 import com.google.auth.Credentials
 import com.google.auth.oauth2.{ServiceAccountCredentials, ServiceAccountJwtAccessCredentials, UserCredentials}
@@ -296,9 +297,17 @@ class BqServiceFactory @Inject() (
 ) extends BecquerelServiceFactory {
 
   factoryRegistry(classOf[BqService].getName) = this
+  private def logger: Logger = Logger(getClass)
 
   override def apply(conf: Configuration, serviceManager: BecquerelServiceManager): BqService = {
-    new BqService(bqConfigFactory(conf))
+    try {
+      val service = new BqService(bqConfigFactory(conf))
+      logger.info(s"Created BqService $service")
+      service
+    } catch  {
+      case e: Exception => logger.error(s"Caught exception: $e")
+        throw e
+    }
   }
 }
 

--- a/app/com/thumbtack/becquerel/datasources/elasticsearch/EsQueryCompiler.scala
+++ b/app/com/thumbtack/becquerel/datasources/elasticsearch/EsQueryCompiler.scala
@@ -19,7 +19,7 @@ package com.thumbtack.becquerel.datasources.elasticsearch
 import com.sksamuel.elastic4s.requests.common.FetchSourceContext
 import com.sksamuel.elastic4s.requests.searches.SearchRequest
 import com.sksamuel.elastic4s.requests.searches.queries.{BoolQuery, Query}
-import com.sksamuel.elastic4s.{Hit, Indexes, IndexesAndTypes}
+import com.sksamuel.elastic4s.{Hit, Indexes}
 import com.thumbtack.becquerel.datasources.{RowMapper, TableMapper}
 import org.apache.olingo.server.api.uri.queryoption._
 
@@ -40,10 +40,6 @@ object EsQueryCompiler {
 
     val (rowMapper: RowMapper[AnyRef, Hit], fetchContext: Option[FetchSourceContext]) = EsSelectCompiler
       .compile(tableMapper, select)
-
-    val indexesAndTypes: IndexesAndTypes = tableMapper.tableIDParts match {
-      case Seq(index, mapping) => IndexesAndTypes(index, mapping)
-    }
 
     val indexes: Indexes = tableMapper.tableIDParts match {
       case Seq(index, _) => Indexes(Seq(index))

--- a/app/com/thumbtack/becquerel/datasources/elasticsearch/EsQueryCompiler.scala
+++ b/app/com/thumbtack/becquerel/datasources/elasticsearch/EsQueryCompiler.scala
@@ -16,12 +16,13 @@
 
 package com.thumbtack.becquerel.datasources.elasticsearch
 
-import com.sksamuel.elastic4s.searches.SearchDefinition
-import com.sksamuel.elastic4s.searches.queries.{BoolQueryDefinition, QueryDefinition}
-import com.sksamuel.elastic4s.{Hit, IndexesAndTypes}
+import com.sksamuel.elastic4s.requests.common.FetchSourceContext
+import com.sksamuel.elastic4s.requests.searches.SearchRequest
+import com.sksamuel.elastic4s.requests.searches.queries.{BoolQuery, Query}
+import com.sksamuel.elastic4s.{Hit, Indexes, IndexesAndTypes}
 import com.thumbtack.becquerel.datasources.{RowMapper, TableMapper}
 import org.apache.olingo.server.api.uri.queryoption._
-import org.elasticsearch.search.fetch.subphase.FetchSourceContext
+
 
 object EsQueryCompiler {
   /**
@@ -35,7 +36,7 @@ object EsQueryCompiler {
     orderBy: Option[OrderByOption],
     top: Option[TopOption],
     skip: Option[SkipOption]
-  ): (RowMapper[AnyRef, Hit], SearchDefinition) = {
+  ): (RowMapper[AnyRef, Hit], SearchRequest) = {
 
     val (rowMapper: RowMapper[AnyRef, Hit], fetchContext: Option[FetchSourceContext]) = EsSelectCompiler
       .compile(tableMapper, select)
@@ -44,20 +45,24 @@ object EsQueryCompiler {
       case Seq(index, mapping) => IndexesAndTypes(index, mapping)
     }
 
-    val filterQuery: Option[QueryDefinition] = EsExpressionCompiler.compileFilter(filter)
-    val searchQuery: Option[QueryDefinition] = EsExpressionCompiler.compileSearch(search)
-    val query: Option[QueryDefinition] = Seq(
+    val indexes: Indexes = tableMapper.tableIDParts match {
+      case Seq(index, _) => Indexes(Seq(index))
+    }
+
+    val filterQuery: Option[Query] = EsExpressionCompiler.compileFilter(filter)
+    val searchQuery: Option[Query] = EsExpressionCompiler.compileSearch(search)
+    val query: Option[Query] = Seq(
       filterQuery,
       searchQuery
     )
       .flatten match {
       case Seq() => None
       case Seq(single) => Some(single)
-      case many => Some(BoolQueryDefinition(must = many))
+      case many => Some(BoolQuery(must = many))
     }
 
-    val searchDefinition = SearchDefinition(
-      indexesTypes = indexesAndTypes,
+    val searchRequest = SearchRequest(
+      indexes = indexes,
       query = query,
       sorts = EsExpressionCompiler.compileOrderBy(orderBy),
       fetchContext = fetchContext,
@@ -65,6 +70,6 @@ object EsQueryCompiler {
       size = top.map(_.getValue)
     )
 
-    (rowMapper, searchDefinition)
+    (rowMapper, searchRequest)
   }
 }

--- a/app/com/thumbtack/becquerel/datasources/elasticsearch/EsSelectCompiler.scala
+++ b/app/com/thumbtack/becquerel/datasources/elasticsearch/EsSelectCompiler.scala
@@ -19,9 +19,9 @@ package com.thumbtack.becquerel.datasources.elasticsearch
 import scala.collection.JavaConverters._
 
 import com.sksamuel.elastic4s.Hit
+import com.sksamuel.elastic4s.requests.common.FetchSourceContext
 import org.apache.olingo.server.api.uri.UriResourceProperty
 import org.apache.olingo.server.api.uri.queryoption.{SelectItem, SelectOption}
-import org.elasticsearch.search.fetch.subphase.FetchSourceContext
 
 import com.thumbtack.becquerel.datasources.{FieldMapper, RowMapper, TableMapper}
 import com.thumbtack.becquerel.util.BecquerelException
@@ -43,11 +43,8 @@ object EsSelectCompiler {
       .map(_.getSelectItems.asScala)
       .map(_.map(resolve(tableMapper)))
       .map { fields =>
-
         val rowMapper = tableMapper.rowMapper.withFields(fields.map(_._1))
-
-        val sourceFilter = new FetchSourceContext(true, fields.map(_._2).toArray, Array.empty[String])
-
+        val sourceFilter = new FetchSourceContext(true, fields.map(_._2).toSet, Set.empty[String])
         (rowMapper, Some(sourceFilter): Option[FetchSourceContext])
       }
       .getOrElse((tableMapper.rowMapper, None)) // Don't filter the source.

--- a/app/com/thumbtack/becquerel/datasources/elasticsearch/EsService.scala
+++ b/app/com/thumbtack/becquerel/datasources/elasticsearch/EsService.scala
@@ -18,21 +18,21 @@ package com.thumbtack.becquerel.datasources.elasticsearch
 
 import java.time.Instant
 import javax.inject.{Inject, Singleton}
-
 import scala.collection.mutable
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
+import play.api.Logger
+import play.api.Configuration
+import play.api.http.Status
 
 import com.codahale.metrics.{Gauge, MetricRegistry}
 import com.sksamuel.elastic4s.Hit
-import com.sksamuel.elastic4s.http.ElasticDsl._
-import com.sksamuel.elastic4s.http.HttpClient
-import com.sksamuel.elastic4s.http.index.mappings.IndexMappings
-import com.sksamuel.elastic4s.searches.SearchDefinition
+import com.sksamuel.elastic4s.ElasticDsl._
+import com.sksamuel.elastic4s.{ElasticClient, ElasticProperties}
+import com.sksamuel.elastic4s.http.JavaClient
+import com.sksamuel.elastic4s.requests.indexes.IndexMappings
+import com.sksamuel.elastic4s.requests.searches.SearchRequest
 import org.apache.olingo.server.api.uri.queryoption._
-import play.api.http.Status
-import play.api.{Configuration, Logger}
-
 import com.thumbtack.becquerel.datasources._
 import com.thumbtack.becquerel.util.BecquerelException
 import com.thumbtack.becquerel.{BecquerelServiceFactory, BecquerelServiceFactoryRegistry, BecquerelServiceManager}
@@ -42,7 +42,7 @@ import com.thumbtack.becquerel.{BecquerelServiceFactory, BecquerelServiceFactory
   */
 class EsService(
   esConfig: EsServiceConfig
-) extends DataSourceService[AnyRef, Hit, Seq[IndexMappings], SearchDefinition] {
+) extends DataSourceService[AnyRef, Hit, Seq[IndexMappings], SearchRequest] {
 
   protected override def dssConfig: DataSourceServiceConfig = esConfig.dssConfig
 
@@ -66,7 +66,7 @@ class EsService(
   /**
     * Uses [[org.apache.http.nio.client.HttpAsyncClient]], which has its own thread pool.
     */
-  protected val actualEsClient: HttpClient = HttpClient(esConfig.url)
+  protected val actualEsClient = ElasticClient(JavaClient(ElasticProperties(esConfig.url)))
 
   /**
     * @return A retrying ES client wrapper from this service's actual ES client and retry config.
@@ -98,40 +98,31 @@ class EsService(
 
     // Fetch the mappings for every index that matches the `indexes` glob.
     val indexMappingsTask: Future[Seq[IndexMappings]] = Future.traverse(esConfig.indexes.toSeq) { glob =>
-      metadataEsClient.execute {
-        // Note: indexes that have disabled mappings with no properties will cause
-        // a `java.util.NoSuchElementException` in `GetMappingHttpExecutable`.
-        // See https://www.elastic.co/guide/en/elasticsearch/reference/current/enabled.html
-        // This looks like an elastic4s bug in parsing the response.
-        getMapping(glob)
-      }
-    }.map(_.flatten)
+      metadataEsClient.execute(getMapping(glob))
+    }.map (_.flatMap(_.result))
 
     // Fetch the mappings for every alias that matches an `aliases` glob.
-    val aliasMappingsTask: Future[Seq[IndexMappings]] = Future.traverse(esConfig.aliases.toSeq) { glob =>
-      metadataEsClient.execute {
-        getAlias(glob)
-      }.flatMap { aliasResponse =>
+    val aliasMappingsTask: Future[Seq[IndexMappings]] = metadataEsClient.execute(getAliases(Nil, esConfig.aliases.toSeq))
+      .flatMap { aliasResponse =>
+        val aliases = aliasResponse.result.mappings.values.flatten
         // Get the alias for every index that has an alias.
-        val aliases = aliasResponse.flatMap { case (_, aliasesForIndex) =>
-          aliasesForIndex.get("aliases").toSeq.flatMap(_.keys)
-        }
         // Fetch the mappings for each unique alias.
         Future.traverse(aliases.toSet.toSeq) { alias =>
-          metadataEsClient.execute {
-            getMapping(alias)
-          }.map { indexMappings =>
-            assert(indexMappings.nonEmpty)
-            if (indexMappings.size > 1) {
-              // TODO: schema merge if multiple indexes are present, such as for a partitioned table.
-              logger.warn(s"Alias $alias maps to multiple indexes. Using schema from the first one.")
+          metadataEsClient.execute(getMapping(alias.name))
+            .map { mappings =>
+              val sortedMappings = mappings.result.sortBy(_.index)((Ordering[String].reverse))
+              assert(sortedMappings.nonEmpty)
+              if (sortedMappings.size > 1) {
+                // TODO: schema merge if multiple indexes are present, such as for a partitioned table.
+                logger.info(s"Alias ${alias.name} maps to multiple indexes. Using schema from the latest one.")
+              }
+              // Get the mappings for the first index, but replace the index name with the alias.
+              // But, we remember the physical index name in the mapping for use later.
+              val updated_mappings = sortedMappings.head.mappings + ("real_index" -> sortedMappings.head.index)
+              sortedMappings.head.copy(index = alias.name, mappings = updated_mappings)
             }
-            // Get the mappings for the first index, but replace the index name with the alias.
-            indexMappings.head.copy(index = alias)
-          }
         }
       }
-    }.map(_.flatten)
 
     // Combine the two lists of mappings.
     for (
@@ -161,7 +152,7 @@ class EsService(
     orderBy: Option[OrderByOption],
     top: Option[TopOption],
     skip: Option[SkipOption]
-  ): (RowMapper[AnyRef, Hit], SearchDefinition) = {
+  ): (RowMapper[AnyRef, Hit], SearchRequest) = {
     // TODO: decorate with run ID (if there's any logging for these queries)
     EsQueryCompiler.compile(
       tableMapper,
@@ -174,14 +165,13 @@ class EsService(
     )
   }
 
-  override def execute(compiledQuery: SearchDefinition): Future[TraversableOnce[Hit]] = {
+  override def execute(compiledQuery: SearchRequest): Future[TraversableOnce[Hit]] = {
     implicit val ec: ExecutionContext = queryEC
 
     queryEsClient
       .execute {
         compiledQuery
-      }
-      .map(_.hits.hits)
+      }.map(_.result.hits.hits)
   }
 
   override def shutdown(): Future[Unit] = {
@@ -203,9 +193,17 @@ class EsServiceFactory @Inject() (
 ) extends BecquerelServiceFactory {
 
   factoryRegistry(classOf[EsService].getName) = this
+  private def logger: Logger = Logger(getClass)
 
   override def apply(conf: Configuration, serviceManager: BecquerelServiceManager): EsService = {
-    new EsService(esConfigFactory(conf))
+    try {
+      val service = new EsService(esConfigFactory(conf))
+      logger.info(s"Created EsService $service")
+      service
+    } catch {
+      case e: Exception => logger.error(s"Caught exception: $e")
+        throw e
+    }
   }
 }
 

--- a/app/com/thumbtack/becquerel/datasources/elasticsearch/EsTableMapper.scala
+++ b/app/com/thumbtack/becquerel/datasources/elasticsearch/EsTableMapper.scala
@@ -17,7 +17,7 @@
 package com.thumbtack.becquerel.datasources.elasticsearch
 
 import com.sksamuel.elastic4s.Hit
-import com.sksamuel.elastic4s.http.index.mappings.IndexMappings
+import com.sksamuel.elastic4s.requests.indexes.IndexMappings
 import com.thumbtack.becquerel.datasources.{ODataStrings, TableMapper}
 import org.apache.olingo.commons.api.edm.FullQualifiedName
 import org.apache.olingo.commons.api.edm.provider.{CsdlEntitySet, CsdlEntityType, CsdlPropertyRef}
@@ -33,9 +33,10 @@ object EsTableMapper {
 
     val indexName = indexMappings.index
 
-    // We expect there to be only one mapping per index.
-    assert(indexMappings.mappings.size == 1)
-    val (mappingName, mapping) = indexMappings.mappings.head
+    // Extract the physical index name from the index mappings and remove the key from the map.
+    // This was inserted by EsService.fetchDefinitions() for this purpose.
+    val mappingName = indexMappings.mappings.getOrElse("real_index", indexName).asInstanceOf[String]
+    val mapping = indexMappings.mappings - "real_index"
 
     val tableIDParts = Seq(indexName, mappingName)
 

--- a/app/com/thumbtack/becquerel/demo/EsDemoLoader.scala
+++ b/app/com/thumbtack/becquerel/demo/EsDemoLoader.scala
@@ -22,7 +22,6 @@ import java.nio.file.Files
 
 import scala.collection.JavaConverters._
 
-import com.sksamuel.elastic4s.IndexAndType
 import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s.{ElasticClient, ElasticProperties, Index, SimpleFieldValue}
 import com.sksamuel.elastic4s.http.JavaClient
@@ -82,25 +81,25 @@ object EsDemoLoader {
       mapping = new MappingDefinition(
         fields = Seq(
           intField(name="customerid"),
-          keywordField(name="firstname"),
-          keywordField(name="lastname"),
-          keywordField(name="address1"),
-          keywordField(name="address2"),
-          keywordField(name="city"),
-          keywordField(name="state"),
-          keywordField(name="zip"),
-          keywordField(name="country"),
-          keywordField(name="region"),
-          keywordField(name="email"),
-          keywordField(name="phone"),
-          keywordField(name="creditcardtype"),
-          keywordField(name="creditcard"),
-          keywordField(name="creditcardexpiration"),
-          keywordField(name="username"),
-          keywordField(name="password"),
+          textField(name="firstname"),
+          textField(name="lastname"),
+          textField(name="address1"),
+          textField(name="address2"),
+          textField(name="city"),
+          textField(name="state"),
+          textField(name="zip"),
+          textField(name="country"),
+          textField(name="region"),
+          textField(name="email"),
+          textField(name="phone"),
+          textField(name="creditcardtype"),
+          textField(name="creditcard"),
+          textField(name="creditcardexpiration"),
+          textField(name="username"),
+          textField(name="password"),
           shortField(name="age"),
           intField(name="income"),
-          keywordField(name="gender")
+          textField(name="gender")
         )
       ),
       parseRow = {
@@ -172,269 +171,168 @@ object EsDemoLoader {
           IndexRequest(
             index = Index(DvdStoreTable.cust_hist.name),
             id = None,
-            fields =Seq(
+            fields = Seq(
               SimpleFieldValue("customerid", customerid.toInt),
               SimpleFieldValue("orderid", orderid.toInt),
               SimpleFieldValue("prod_id", prod_id.toInt)
             )
           )
       }
-    )
-      /*
+    ),
     EsDvdStoreTable(
       dvdStoreTable = DvdStoreTable.orders,
-      mapping = MappingDefinition(
-        `type` = esDocType,
+      mapping = new MappingDefinition(
         fields = Seq(
-          BasicFieldDefinition(
-            name = "orderid",
-            `type` = "integer",
-            nullable = Some(false)
-          ),
-          BasicFieldDefinition(
-            name = "orderdate",
-            `type` = "date",
-            format = Some("strict_date"),
-            nullable = Some(false)
-          ),
-          BasicFieldDefinition(
-            name = "customerid",
-            `type` = "integer",
-            nullable = Some(true)
-          ),
-          BasicFieldDefinition(
-            name = "netamount",
-            `type` = "scaled_float",
-            nullable = Some(false),
-            scalingFactor = Option(100.0)
-          ),
-          BasicFieldDefinition(
-            name = "tax",
-            `type` = "scaled_float",
-            nullable = Some(false),
-            scalingFactor = Option(100.0)
-          ),
-          BasicFieldDefinition(
-            name = "totalamount",
-            `type` = "scaled_float",
-            nullable = Some(false),
-            scalingFactor = Option(100.0)
-          )
+          intField(name = "orderid"),
+          dateField(name = "orderdate"),
+          intField(name = "customerid"),
+          scaledFloatField(name = "netamount"),
+          scaledFloatField(name = "tax"),
+          scaledFloatField(name = "totalamount")
         )
       ),
       parseRow = {
         case Array(
-        orderid,
-        orderdate,
-        customerid,
-        netamount,
-        tax,
-        totalamount
+          orderid,
+          orderdate,
+          customerid,
+          netamount,
+          tax,
+          totalamount
         ) =>
           IndexRequest(
-//            indexAndType = stubIndexAndType,
-            id = Some(orderid.toInt)
-          ).fields(
-            "orderid" -> orderid.toInt,
-            "orderdate" -> java.sql.Date.valueOf(orderdate.replace('/', '-')),
-            "customerid" -> Option(customerid).map(_.toInt).orNull,
-            "netamount" -> BigDecimal.exact(netamount),
-            "tax" -> BigDecimal.exact(tax),
-            "totalamount" -> BigDecimal.exact(totalamount)
+            index = Index(DvdStoreTable.orders.name),
+            id = Some(orderid),
+            fields = Seq(
+              SimpleFieldValue("orderid", orderid.toInt),
+              SimpleFieldValue("orderdate", java.sql.Date.valueOf(orderdate.replace('/', '-'))),
+              SimpleFieldValue("customerid", Option(customerid).map(_.toInt).getOrElse(None)),
+              SimpleFieldValue("netamount", BigDecimal.exact(netamount)),
+              SimpleFieldValue("tax", BigDecimal.exact(tax)),
+              SimpleFieldValue("totalamount", BigDecimal.exact(totalamount))
+            )
           )
       }
     ),
     EsDvdStoreTable(
       dvdStoreTable = DvdStoreTable.orderlines,
-      mapping = MappingDefinition(
-        `type` = esDocType,
+      mapping = new MappingDefinition(
         fields = Seq(
-          BasicFieldDefinition(
-            name = "orderlineid",
-            `type` = "short",
-            nullable = Some(false)
-          ),
-          BasicFieldDefinition(
-            name = "orderid",
-            `type` = "integer",
-            nullable = Some(false)
-          ),
-          BasicFieldDefinition(
-            name = "prod_id",
-            `type` = "integer",
-            nullable = Some(false)
-          ),
-          BasicFieldDefinition(
-            name = "quantity",
-            `type` = "short",
-            nullable = Some(false)
-          ),
-          BasicFieldDefinition(
-            name = "orderdate",
-            `type` = "date",
-            format = Some("strict_date"),
-            nullable = Some(false)
-          )
+          shortField(name = "orderlineid"),
+          intField(name = "orderid"),
+          intField(name = "prod_id"),
+          shortField(name = "quantity"),
+          dateField(name = "orderdate")
         )
       ),
       parseRow = {
         case Array(
-        orderlineid,
-        orderid,
-        prod_id,
-        quantity,
-        orderdate
+          orderlineid,
+          orderid,
+          prod_id,
+          quantity,
+          orderdate
         ) =>
           IndexRequest(
-//            indexAndType = stubIndexAndType,
-            id = None
-          ).fields(
-            "orderlineid" -> orderlineid.toShort,
-            "orderid" -> orderid.toInt,
-            "prod_id" -> prod_id.toInt,
-            "quantity" -> quantity.toShort,
-            "orderdate" -> java.sql.Date.valueOf(orderdate.replace('/', '-'))
+            index = Index(DvdStoreTable.orderlines.name),
+            id = None,
+            fields = Seq(
+              SimpleFieldValue("orderlineid", orderlineid.toShort),
+              SimpleFieldValue("orderid", orderid.toInt),
+              SimpleFieldValue("prod_id", prod_id.toInt),
+              SimpleFieldValue("quantity", quantity.toShort),
+              SimpleFieldValue("orderdate", java.sql.Date.valueOf(orderdate.replace('/', '-')))
+            )
           )
       }
     ),
     EsDvdStoreTable(
       dvdStoreTable = DvdStoreTable.products,
-      mapping = MappingDefinition(
-        `type` = esDocType,
+      mapping = new MappingDefinition(
         fields = Seq(
-          BasicFieldDefinition(
-            name = "prod_id",
-            `type` = "integer",
-            nullable = Some(false)
-          ),
-          BasicFieldDefinition(
-            name = "category",
-            `type` = "short",
-            nullable = Some(false)
-          ),
-          BasicFieldDefinition(
-            name = "title",
-            `type` = "keyword",
-            nullable = Some(false)
-          ),
-          BasicFieldDefinition(
-            name = "actor",
-            `type` = "keyword",
-            nullable = Some(false)
-          ),
-          BasicFieldDefinition(
-            name = "price",
-            `type` = "scaled_float",
-            nullable = Some(false),
-            scalingFactor = Option(100.0)
-          ),
-          BasicFieldDefinition(
-            name = "special",
-            `type` = "short",
-            nullable = Some(true)
-          ),
-          BasicFieldDefinition(
-            name = "common_prod_id",
-            `type` = "integer",
-            nullable = Some(false)
-          )
+          intField(name = "prod_id"),
+          shortField(name = "category"),
+          keywordField(name = "title"),
+          keywordField(name = "actor"),
+          scaledFloatField(name = "price").scalingFactor(100.0),
+          shortField(name = "special").nullable(true),
+          intField(name = "common_prod_id")
         )
       ),
       parseRow = {
         case Array(
-        prod_id,
-        category,
-        title,
-        actor,
-        price,
-        special,
-        common_prod_id
+          prod_id,
+          category,
+          title,
+          actor,
+          price,
+          special,
+          common_prod_id
         ) =>
           IndexRequest(
-//            indexAndType = stubIndexAndType,
-            id = Some(prod_id.toInt)
-          ).fields(
-            "prod_id" -> prod_id.toInt,
-            "category" -> category.toShort,
-            "title" -> title,
-            "actor" -> actor,
-            "price" -> BigDecimal.exact(price),
-            "special" -> Option(special).map(_.toShort).orNull,
-            "common_prod_id" -> common_prod_id.toInt
+            index = Index(DvdStoreTable.products.name),
+            id = Some(prod_id),
+            fields = Seq(
+              SimpleFieldValue("prod_id", prod_id.toInt),
+              SimpleFieldValue("category", category.toShort),
+              SimpleFieldValue("title", title),
+              SimpleFieldValue("actor", actor),
+              SimpleFieldValue("price", BigDecimal.exact(price)),
+              SimpleFieldValue("special", Option(special).map(_.toShort).getOrElse(None)),
+              SimpleFieldValue("common_prod_id", common_prod_id.toInt)
+            )
           )
       }
     ),
     EsDvdStoreTable(
       dvdStoreTable = DvdStoreTable.inventory,
-      mapping = MappingDefinition(
-        `type` = esDocType,
+      mapping = new MappingDefinition(
         fields = Seq(
-          BasicFieldDefinition(
-            name = "prod_id",
-            `type` = "integer",
-            nullable = Some(false)
-          ),
-          BasicFieldDefinition(
-            name = "quan_in_stock",
-            `type` = "integer",
-            nullable = Some(false)
-          ),
-          BasicFieldDefinition(
-            name = "sales",
-            `type` = "integer",
-            nullable = Some(false)
-          )
+          intField(name = "prod_id"),
+          intField(name = "quan_in_stock"),
+          intField(name = "sales")
         )
       ),
       parseRow = {
         case Array(
-        prod_id,
-        quan_in_stock,
-        sales
+          prod_id,
+          quan_in_stock,
+          sales
         ) =>
           IndexRequest(
-//            indexAndType = stubIndexAndType,
-            id = Some(prod_id.toInt)
-          ).fields(
-            "prod_id" -> prod_id.toInt,
-            "quan_in_stock" -> quan_in_stock.toInt,
-            "sales" -> sales.toInt
+            index = Index(DvdStoreTable.inventory.name),
+            id = Some(prod_id),
+            fields = Seq(
+              SimpleFieldValue("prod_id", prod_id.toInt),
+              SimpleFieldValue("quan_in_stock", quan_in_stock.toInt),
+              SimpleFieldValue("sales", sales.toInt)
+            )
           )
       }
     ),
     EsDvdStoreTable(
       dvdStoreTable = DvdStoreTable.categories,
-      mapping = MappingDefinition(
-        `type` = esDocType,
+      mapping = new MappingDefinition(
         fields = Seq(
-          BasicFieldDefinition(
-            name = "category",
-            `type` = "integer",
-            nullable = Some(false)
-          ),
-          BasicFieldDefinition(
-            name = "categoryname",
-            `type` = "keyword",
-            nullable = Some(false)
-          )
+          intField(name = "category"),
+          keywordField(name = "categoryname")
         )
       ),
       parseRow = {
         case Array(
-        category,
-        categoryname
+          category,
+          categoryname
         ) =>
           IndexRequest(
-//            indexAndType = stubIndexAndType,
-            id = Some(category.toInt)
-          ).fields(
-            "category" -> category.toInt,
-            "categoryname" -> categoryname
+            index = Index(DvdStoreTable.categories.name),
+            id = Some(category),
+            fields = Seq(
+              SimpleFieldValue("category", category.toInt),
+              SimpleFieldValue("categoryname", categoryname)
+            )
           )
       }
     )
-
-       */
   )
 }
 

--- a/app/com/thumbtack/becquerel/demo/EsDemoLoader.scala
+++ b/app/com/thumbtack/becquerel/demo/EsDemoLoader.scala
@@ -75,7 +75,6 @@ object EsDemoLoader {
   }
 
   private[demo] val esDocType = "row"
-  private[demo] val stubIndexAndType = IndexAndType("", "")
 
   private[demo] val esTables = Seq[EsDvdStoreTable](
     EsDvdStoreTable(

--- a/app/com/thumbtack/becquerel/demo/EsDemoLoader.scala
+++ b/app/com/thumbtack/becquerel/demo/EsDemoLoader.scala
@@ -23,10 +23,11 @@ import java.nio.file.Files
 import scala.collection.JavaConverters._
 
 import com.sksamuel.elastic4s.IndexAndType
-import com.sksamuel.elastic4s.http.ElasticDsl._
-import com.sksamuel.elastic4s.http.HttpClient
-import com.sksamuel.elastic4s.indexes.IndexDefinition
-import com.sksamuel.elastic4s.mappings.{BasicFieldDefinition, MappingDefinition}
+import com.sksamuel.elastic4s.ElasticDsl._
+import com.sksamuel.elastic4s.{ElasticClient, ElasticProperties, Index, SimpleFieldValue}
+import com.sksamuel.elastic4s.http.JavaClient
+import com.sksamuel.elastic4s.requests.indexes.IndexRequest
+import com.sksamuel.elastic4s.requests.mappings.MappingDefinition
 import com.typesafe.config.{Config, ConfigFactory}
 import com.univocity.parsers.common.ParsingContext
 import com.univocity.parsers.common.processor.RowProcessor
@@ -40,13 +41,12 @@ import resource._
 object EsDemoLoader {
 
   def main(args: Array[String]): Unit = {
-    for (esHttpClient <- managed(HttpClient(EsDemoConfig.url))) {
+    for (esClient <- managed(ElasticClient(JavaClient(ElasticProperties(EsDemoConfig.url))))) {
       for (esTable <- esTables) {
-
         val indexName = s"${EsDemoConfig.indexPrefix}${esTable.dvdStoreTable.name}"
 
         try {
-          esHttpClient.execute {
+          esClient.execute {
             deleteIndex(indexName)
           }.await
           println(s"Deleted index $indexName.")
@@ -55,7 +55,7 @@ object EsDemoLoader {
             // The index doesn't exist so we don't need to delete it.
         }
 
-        esHttpClient.execute {
+        esClient.execute {
           createIndex(indexName) mappings esTable.mapping
         }.await
         println(s"Created index $indexName.")
@@ -64,7 +64,7 @@ object EsDemoLoader {
           println(s"Copying $csvPath into $indexName.")
 
           val settings = new CsvParserSettings()
-          val rowProcessor = new EsWriterRowProcessor(esTable, indexName, esHttpClient)
+          val rowProcessor = new EsWriterRowProcessor(esTable, indexName, esClient)
           settings.setProcessor(rowProcessor)
 
           val parser = new CsvParser(settings)
@@ -80,109 +80,28 @@ object EsDemoLoader {
   private[demo] val esTables = Seq[EsDvdStoreTable](
     EsDvdStoreTable(
       dvdStoreTable = DvdStoreTable.customers,
-      mapping = MappingDefinition(
-        `type` = esDocType,
+      mapping = new MappingDefinition(
         fields = Seq(
-          BasicFieldDefinition(
-            name = "customerid",
-            `type` = "integer",
-            nullable = Some(false)
-          ),
-          BasicFieldDefinition(
-            name = "firstname",
-            `type` = "keyword",
-            nullable = Some(false)
-          ),
-          BasicFieldDefinition(
-            name = "lastname",
-            `type` = "keyword",
-            nullable = Some(false)
-          ),
-          BasicFieldDefinition(
-            name = "address1",
-            `type` = "keyword",
-            nullable = Some(false)
-          ),
-          BasicFieldDefinition(
-            name = "address2",
-            `type` = "long",
-            nullable = Some(true)
-          ),
-          BasicFieldDefinition(
-            name = "city",
-            `type` = "keyword",
-            nullable = Some(false)
-          ),
-          BasicFieldDefinition(
-            name = "state",
-            `type` = "keyword",
-            nullable = Some(true)
-          ),
-          BasicFieldDefinition(
-            name = "zip",
-            `type` = "keyword",
-            nullable = Some(true)
-          ),
-          BasicFieldDefinition(
-            name = "country",
-            `type` = "keyword",
-            nullable = Some(false)
-          ),
-          BasicFieldDefinition(
-            name = "region",
-            `type` = "short",
-            nullable = Some(false)
-          ),
-          BasicFieldDefinition(
-            name = "email",
-            `type` = "keyword",
-            nullable = Some(true)
-          ),
-          BasicFieldDefinition(
-            name = "phone",
-            `type` = "keyword",
-            nullable = Some(true)
-          ),
-          BasicFieldDefinition(
-            name = "creditcardtype",
-            `type` = "integer",
-            nullable = Some(false)
-          ),
-          BasicFieldDefinition(
-            name = "creditcard",
-            `type` = "keyword",
-            nullable = Some(false)
-          ),
-          BasicFieldDefinition(
-            name = "creditcardexpiration",
-            `type` = "keyword",
-            nullable = Some(false)
-          ),
-          BasicFieldDefinition(
-            name = "username",
-            `type` = "keyword",
-            nullable = Some(false)
-          ),
-          BasicFieldDefinition(
-            name = "password",
-            `type` = "keyword",
-            nullable = Some(false)
-          ),
-          BasicFieldDefinition(
-            name = "age",
-            `type` = "short",
-            nullable = Some(true)
-          ),
-          BasicFieldDefinition(
-            name = "income",
-            `type` = "integer",
-            nullable = Some(true)
-          ),
-          BasicFieldDefinition(
-            name = "gender",
-            `type` = "keyword",
-            nullable = Some(true)
-          )
+          intField(name="customerid"),
+          keywordField(name="firstname"),
+          keywordField(name="lastname"),
+          keywordField(name="address1"),
+          keywordField(name="address2"),
+          keywordField(name="city"),
+          keywordField(name="state"),
+          keywordField(name="zip"),
+          keywordField(name="country"),
+          keywordField(name="region"),
+          keywordField(name="email"),
+          keywordField(name="phone"),
+          keywordField(name="creditcardtype"),
+          keywordField(name="creditcard"),
+          keywordField(name="creditcardexpiration"),
+          keywordField(name="username"),
+          keywordField(name="password"),
+          shortField(name="age"),
+          intField(name="income"),
+          keywordField(name="gender")
         )
       ),
       parseRow = {
@@ -208,71 +127,61 @@ object EsDemoLoader {
           income,
           gender
         ) =>
-          IndexDefinition(
-            indexAndType = stubIndexAndType,
-            id = Some(customerid.toInt)
-          ).fields(
-            "customerid" -> customerid.toInt,
-            "firstname" -> firstname,
-            "lastname" -> lastname,
-            "address1" -> address1,
-            "address2" -> address2,
-            "city" -> city,
-            "state" -> state,
-            "zip" -> zip,
-            "country" -> country,
-            "region" -> region.toShort,
-            "email" -> email,
-            "phone" -> phone,
-            "creditcardtype" -> creditcardtype.toInt,
-            "creditcard" -> creditcard,
-            "creditcardexpiration" -> creditcardexpiration,
-            "username" -> username,
-            "password" -> password,
-            "age" -> Option(age).map(_.toInt).orNull,
-            "income" -> Option(income).map(_.toInt).orNull,
-            "gender" -> gender
+          IndexRequest(
+            index = Index(DvdStoreTable.customers.name),
+            id = Some(customerid),
+            fields = Seq(
+              SimpleFieldValue("customerid", customerid.toInt),
+              SimpleFieldValue("firstname", firstname),
+              SimpleFieldValue("lastname", lastname),
+              SimpleFieldValue("address1", address1),
+              SimpleFieldValue("address2", address2),
+              SimpleFieldValue("city", city),
+              SimpleFieldValue("state", state),
+              SimpleFieldValue("zip", zip),
+              SimpleFieldValue("country", country),
+              SimpleFieldValue("region", region.toShort),
+              SimpleFieldValue("email", email),
+              SimpleFieldValue("phone", phone),
+              SimpleFieldValue("creditcardtype", creditcardtype.toInt),
+              SimpleFieldValue("creditcard", creditcard),
+              SimpleFieldValue("creditcardexpiration", creditcardexpiration),
+              SimpleFieldValue("username", username),
+              SimpleFieldValue("password", password),
+              SimpleFieldValue("age", Option(age).map(_.toInt)),
+              SimpleFieldValue("income", Option(income).map(_.toInt)),
+              SimpleFieldValue("gender", gender)
+            )
           )
       }
     ),
     EsDvdStoreTable(
       dvdStoreTable = DvdStoreTable.cust_hist,
-      mapping = MappingDefinition(
-        `type` = esDocType,
+      mapping = new MappingDefinition(
         fields = Seq(
-          BasicFieldDefinition(
-            name = "customerid",
-            `type` = "integer",
-            nullable = Some(false)
-          ),
-          BasicFieldDefinition(
-            name = "orderid",
-            `type` = "integer",
-            nullable = Some(false)
-          ),
-          BasicFieldDefinition(
-            name = "prod_id",
-            `type` = "integer",
-            nullable = Some(false)
-          )
+          intField(name = "customerid"),
+          intField(name = "orderid"),
+          intField(name = "prod_id")
         )
       ),
       parseRow = {
         case Array(
-        customerid,
-        orderid,
-        prod_id
+          customerid,
+          orderid,
+          prod_id
         ) =>
-          IndexDefinition(
-            indexAndType = stubIndexAndType,
-            id = None
-          ).fields(
-            "customerid" -> customerid.toInt,
-            "orderid" -> orderid.toInt,
-            "prod_id" -> prod_id.toInt
+          IndexRequest(
+            index = Index(DvdStoreTable.cust_hist.name),
+            id = None,
+            fields =Seq(
+              SimpleFieldValue("customerid", customerid.toInt),
+              SimpleFieldValue("orderid", orderid.toInt),
+              SimpleFieldValue("prod_id", prod_id.toInt)
+            )
           )
       }
-    ),
+    )
+      /*
     EsDvdStoreTable(
       dvdStoreTable = DvdStoreTable.orders,
       mapping = MappingDefinition(
@@ -323,8 +232,8 @@ object EsDemoLoader {
         tax,
         totalamount
         ) =>
-          IndexDefinition(
-            indexAndType = stubIndexAndType,
+          IndexRequest(
+//            indexAndType = stubIndexAndType,
             id = Some(orderid.toInt)
           ).fields(
             "orderid" -> orderid.toInt,
@@ -377,8 +286,8 @@ object EsDemoLoader {
         quantity,
         orderdate
         ) =>
-          IndexDefinition(
-            indexAndType = stubIndexAndType,
+          IndexRequest(
+//            indexAndType = stubIndexAndType,
             id = None
           ).fields(
             "orderlineid" -> orderlineid.toShort,
@@ -442,8 +351,8 @@ object EsDemoLoader {
         special,
         common_prod_id
         ) =>
-          IndexDefinition(
-            indexAndType = stubIndexAndType,
+          IndexRequest(
+//            indexAndType = stubIndexAndType,
             id = Some(prod_id.toInt)
           ).fields(
             "prod_id" -> prod_id.toInt,
@@ -484,8 +393,8 @@ object EsDemoLoader {
         quan_in_stock,
         sales
         ) =>
-          IndexDefinition(
-            indexAndType = stubIndexAndType,
+          IndexRequest(
+//            indexAndType = stubIndexAndType,
             id = Some(prod_id.toInt)
           ).fields(
             "prod_id" -> prod_id.toInt,
@@ -516,8 +425,8 @@ object EsDemoLoader {
         category,
         categoryname
         ) =>
-          IndexDefinition(
-            indexAndType = stubIndexAndType,
+          IndexRequest(
+//            indexAndType = stubIndexAndType,
             id = Some(category.toInt)
           ).fields(
             "category" -> category.toInt,
@@ -525,6 +434,8 @@ object EsDemoLoader {
           )
       }
     )
+
+       */
   )
 }
 
@@ -535,7 +446,7 @@ object EsDemoConfig {
     ).asJava))
     .getConfig("es")
     .withFallback(ConfigFactory.parseMap(Map(
-      "url" -> "elasticsearch://localhost:9200",
+      "url" -> "http://localhost:9200",
       "indexPrefix" -> ""
     ).asJava))
   lazy val url: String = es.getString("url")
@@ -548,13 +459,16 @@ object EsDemoConfig {
 private[demo] case class EsDvdStoreTable(
   dvdStoreTable: DvdStoreTable,
   mapping: MappingDefinition,
-  parseRow: Array[String] => IndexDefinition
+  parseRow: Array[String] => IndexRequest
 )
 
-private[demo] class EsWriterRowProcessor(esTable: EsDvdStoreTable, indexName: String, esHttpClient: HttpClient) extends RowProcessor {
+private[demo] class EsWriterRowProcessor(
+  esTable: EsDvdStoreTable,
+  indexName: String,
+  esHttpClient: ElasticClient) extends RowProcessor {
 
   private val batchSize = 1000
-  private var batch = Seq.newBuilder[IndexDefinition]
+  private var batch = Seq.newBuilder[IndexRequest]
   private var rows = 0
 
   override def processStarted(context: ParsingContext): Unit = {
@@ -562,7 +476,7 @@ private[demo] class EsWriterRowProcessor(esTable: EsDvdStoreTable, indexName: St
   }
 
   override def rowProcessed(row: Array[String], context: ParsingContext): Unit = {
-    batch += esTable.parseRow(row).copy(indexAndType = IndexAndType(indexName, EsDemoLoader.esDocType))
+    batch += esTable.parseRow(row)
     rows += 1
     if (rows == batchSize) {
       writeBatch()

--- a/app/com/thumbtack/becquerel/demo/EsDemoLoader.scala
+++ b/app/com/thumbtack/becquerel/demo/EsDemoLoader.scala
@@ -56,7 +56,7 @@ object EsDemoLoader {
         }
 
         esClient.execute {
-          createIndex(indexName) mappings esTable.mapping
+          createIndex(indexName) mapping esTable.mapping
         }.await
         println(s"Created index $indexName.")
 

--- a/build.sbt
+++ b/build.sbt
@@ -70,7 +70,9 @@ libraryDependencies ++= Seq(
   "com.twitter" %% "util-core" % "6.42.0",
   // Play filter for DropWizard metrics library.
   // This is the forked version from https://github.com/breadfan/metrics-play that supports Play 2.5.
-  "de.threedimensions" %% "metrics-play" % "2.5.13",
+  // 2023-10-26: This library was moved to com.kenshoo
+  // (https://mvnrepository.com/artifact/de.threedimensions/metrics-play)
+  "com.kenshoo" %% "metrics-play" % "2.5.9_0.5.1",
   // Report DropWizard metrics to InfluxDB.
   "com.izettle" % "dropwizard-metrics-influxdb" % "1.1.8" excludeAll(
     ExclusionRule("com.fasterxml.jackson.core", "jackson-core"),

--- a/build.sbt
+++ b/build.sbt
@@ -46,7 +46,7 @@ scalaVersion := "2.11.8"
 
 val googleCloudVersion = "0.8.3-beta"
 val olingoVersion = "4.3.0"
-val elastic4sVersion = "5.4.9"
+val elastic4sVersion = "7.1.0"
 val log4jVersion = "2.8.2"
 
 libraryDependencies ++= Seq(
@@ -85,8 +85,8 @@ libraryDependencies ++= Seq(
   "org.postgresql" % "postgresql" % "42.1.1",
 
   // Elasticsearch backend.
-  "com.sksamuel.elastic4s" %% "elastic4s-http" % elastic4sVersion,
-  "com.sksamuel.elastic4s" %% "elastic4s-play-json" % elastic4sVersion,
+  "com.sksamuel.elastic4s" %% "elastic4s-core" % elastic4sVersion,
+  "com.sksamuel.elastic4s" %% "elastic4s-client-esjava" % "7.0.3",
   // elastic4s depends on the official ES client, which uses Log4j 2, which we don't want.
   // Redirect Log4j to SLF.
   "org.apache.logging.log4j" % "log4j-api" % log4jVersion,

--- a/test/com/thumbtack/becquerel/datasources/elasticsearch/EsSelectCompilerTest.scala
+++ b/test/com/thumbtack/becquerel/datasources/elasticsearch/EsSelectCompilerTest.scala
@@ -19,14 +19,15 @@ package com.thumbtack.becquerel.datasources.elasticsearch
 import java.time.Instant
 
 import com.sksamuel.elastic4s.Hit
-import com.sksamuel.elastic4s.http.index.mappings.IndexMappings
+import com.sksamuel.elastic4s.requests.common.FetchSourceContext
+import com.sksamuel.elastic4s.requests.indexes.IndexMappings
 import com.thumbtack.becquerel.datasources.{DataSourceMetadata, TableMapper}
 import org.apache.olingo.commons.api.edm.{Edm, EdmEntityType}
 import org.apache.olingo.commons.api.edmx.EdmxReference
 import org.apache.olingo.server.api.OData
 import org.apache.olingo.server.core.uri.parser.UriTokenizer.TokenKind
 import org.apache.olingo.server.core.uri.parser.{SelectParser, UriTokenizer}
-import org.elasticsearch.search.fetch.subphase.FetchSourceContext
+
 import org.scalatest.FunSuite
 
 import scala.collection.JavaConverters._
@@ -38,17 +39,9 @@ class EsSelectCompilerTest extends FunSuite {
   val indexMappings: IndexMappings = IndexMappings(
     index = "test__customers",
     mappings = Map(
-      "row" -> Map(
-        "id" -> Map(
-          "type" -> "long"
-        ),
-        "first_name" -> Map(
-          "type" -> "keyword"
-        ),
-        "last_name" -> Map(
-          "type" -> "keyword"
-        )
-      )
+      "id" -> Map("type" -> "long"),
+      "first_name" -> Map("type" -> "keyword"),
+      "last_name" -> Map("type" -> "keyword")
     )
   )
 
@@ -87,8 +80,8 @@ class EsSelectCompilerTest extends FunSuite {
       selectText = "id",
       expectedFetchContext = Some(new FetchSourceContext(
         true,
-        Array("id"),
-        Array()
+        Set("id"),
+        Set()
       ))
     )
   }
@@ -98,8 +91,8 @@ class EsSelectCompilerTest extends FunSuite {
       selectText = "first_name",
       expectedFetchContext = Some(new FetchSourceContext(
         true,
-        Array("first_name"),
-        Array()
+        Set("first_name"),
+        Set()
       ))
     )
   }
@@ -109,8 +102,8 @@ class EsSelectCompilerTest extends FunSuite {
       selectText = "id,first_name",
       expectedFetchContext = Some(new FetchSourceContext(
         true,
-        Array("id", "first_name"),
-        Array()
+        Set("id", "first_name"),
+        Set()
       ))
     )
   }

--- a/test/com/thumbtack/becquerel/datasources/elasticsearch/mocks/MockHttpAsyncClient.scala
+++ b/test/com/thumbtack/becquerel/datasources/elasticsearch/mocks/MockHttpAsyncClient.scala
@@ -52,9 +52,14 @@ class MockHttpAsyncClient(succeedAfter: Int) extends CloseableHttpAsyncClient {
         null
       )
     )
+
     responseConsumer.responseReceived(response)
     responseConsumer.responseCompleted(context)
-    callback.completed(response.asInstanceOf[T])
+    if (numRequests > succeedAfter) {
+      callback.completed(response.asInstanceOf[T])
+    } else {
+      callback.failed(new Exception("Mock exception"))
+    }
     null
   }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.3-SNAPSHOT"
+version in ThisBuild := "1.1.0-SNAPSHOT"


### PR DESCRIPTION
Make adjustments based on significant changes to the elastic4s library.

Update the retry logic to retry based on any failure, instead of
specific status codes, since the status codes are not available via
the new API, at least not without significant change to the codebase.

Tested by running the becquerel service locally with ES tunneled to
Dev ES cluster. Ran dozer in Dev, with copy of prod BQ data, to keep
the data in ES close to prod. Ran a few queries from production to
compare results.